### PR TITLE
Not wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,7 @@ lsm9ds1.o : lsm9ds1.c lsm9ds1.h
 clean :
 	rm -rf *.o i2c
 
-.PHONY : clean
+remake : clean i2c
+
+.PHONY : clean remake
 

--- a/i2c.c
+++ b/i2c.c
@@ -17,7 +17,7 @@ int main() {
   // Range is 0x03 to 0x77
   // 0x6A is the slave address for the accelerometer and gyro on an LSM9DS1
   // with the SA0 line pulled low
-  int addr = 0x6A;
+  uint8_t addr = 0x6A;
   set_slave(i2c,addr);
 
   if(i2c == -1) // Something terrible has happened

--- a/i2c.c
+++ b/i2c.c
@@ -11,14 +11,14 @@
 int main() {
 
   // Setup the GPIO interface
-  wiringPiSetupSys();
+  int i2c = open_i2c(1);
 
   // This is the 7 bit slave address we want to write to.
   // Range is 0x03 to 0x77
   // 0x6A is the slave address for the accelerometer and gyro on an LSM9DS1
   // with the SA0 line pulled low
   int addr = 0x6A;
-  int i2c = wiringPiI2CSetup(addr);
+  set_slave(i2c,addr);
 
   if(i2c == -1) // Something terrible has happened
   {

--- a/libi2c.c
+++ b/libi2c.c
@@ -3,9 +3,73 @@
  */
 
 #include "libi2c.h"
+#include <linux/i2c.h>
 #include <linux/i2c-dev.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
 #include <sys/ioctl.h>
+#include <string.h>
 
-int set_slave(int fd, int address) {
+uint8_t i2c_slave_addr;
+
+int open_i2c(int bus) {
+  char filename[20];
+  snprintf(filename, 19, "/dev/i2c-%d", bus);
+  return open(filename, O_RDWR);
+}
+
+int set_slave(int fd, uint8_t address) {
+  i2c_slave_addr = address;
   return ioctl(fd, I2C_SLAVE, address);
 }
+
+int write_byte(int fd, uint8_t reg, uint8_t byte) {
+  uint8_t buf[2];
+  buf[0] = reg;
+  buf[1] = byte;
+
+  return write(fd, buf, 2);
+}
+
+int write_bytes(int fd, uint8_t reg, uint8_t* bytes, size_t count) {
+  uint8_t* buffer = malloc(count+1);
+  buffer[0] = reg;
+  memcpy(buffer+1,bytes,count);
+
+  int ret = write(fd,buffer,count+1);
+  free(buffer);
+  return ret;
+}
+
+int read_byte(int fd, uint8_t reg, uint8_t* byte) {
+  return read_bytes(fd,reg,byte,1);
+}
+
+int read_bytes(int fd, uint8_t reg, uint8_t* bytes, size_t num) {
+
+  struct i2c_msg* msgs = malloc(sizeof(struct i2c_msg)*(num+1));
+
+  msgs[0].addr = i2c_slave_addr;
+  msgs[0].flags = 0x00;
+  msgs[0].len = 1;
+  msgs[0].buf = &reg;
+
+  msgs[1].addr = i2c_slave_addr;
+  msgs[1].flags = I2C_M_RD;
+  msgs[1].len = (uint16_t)num;
+  msgs[1].buf = bytes;
+
+  struct i2c_rdwr_ioctl_data data;
+  data.msgs = msgs;
+  data.nmsgs = 2;
+
+  int ret = ioctl(fd, I2C_RDWR, &data);
+  free(msgs);
+  return ret;
+}
+

--- a/libi2c.h
+++ b/libi2c.h
@@ -5,6 +5,16 @@
 #ifndef MM_I2C_H
 #define MM_I2C_H
 
-int set_slave(int fd, int address);
+#include <stdint.h>
+#include <stddef.h>
+
+extern uint8_t i2c_slave_addr;
+
+int open_i2c(int bus);
+int set_slave(int fd, uint8_t address);
+int write_byte(int fd, uint8_t reg, uint8_t byte);
+int write_bytes(int fd, uint8_t reg, uint8_t* bytes, size_t count);
+int read_byte(int fd, uint8_t reg, uint8_t* byte);
+int read_bytes(int fd, uint8_t reg, uint8_t* bytes, size_t num);
 
 #endif

--- a/lsm9ds1.c
+++ b/lsm9ds1.c
@@ -23,7 +23,7 @@ void get_gyro(int fd, struct g_data* data)
   if(!data)
     return;
 
-  read_bytes(fd,OUT_X_L_G,data,6);
+  read_bytes(fd,OUT_X_L_G,(uint8_t*)data,6);
 }
 
 /*
@@ -58,7 +58,7 @@ void get_accel(int fd, struct a_data* data)
 
 int get_status(int fd)
 {
-  int stat;
+  uint8_t stat;
   read_byte(fd,STATUS_REG1,&stat);
   return stat;
 }

--- a/lsm9ds1.c
+++ b/lsm9ds1.c
@@ -1,6 +1,5 @@
 #include "lsm9ds1.h"
-#include <wiringPiI2C.h>
-#include <wiringPi.h>
+#include "libi2c.h"
 
 int set_odr(int fd, int odr)
 {
@@ -8,13 +7,14 @@ int set_odr(int fd, int odr)
   int shifted = (odr << 5) & 0xE0;
 
   // get the current CTRL_REG_1
-  int ctrl_reg1 = wiringPiI2CReadReg8(fd,CTRL_REG1_G);
+  uint8_t ctrl_reg1;
+  read_byte(fd,CTRL_REG1_G,&ctrl_reg1);
 
   // Set the ODR bits
   ctrl_reg1 |= shifted;
 
   // Write back CTRL_REG_1
-  return wiringPiI2CWriteReg8(fd,CTRL_REG1_G,ctrl_reg1);
+  return write_byte(fd,CTRL_REG1_G,ctrl_reg1);
 }
 
 void get_gyro(int fd, struct g_data* data)
@@ -23,37 +23,10 @@ void get_gyro(int fd, struct g_data* data)
   if(!data)
     return;
 
-  // These will hold the individual bytes read from the device
-  int x_h,x_l,y_h,y_l,z_h,z_l;
-
-  // Read the high and low bytes
-  // A note, this is probably not the most efficient way to do this as every
-  // read statement is a seperate I2C transaction. It's probably not worth it
-  // but you can get even faster throughput(theoretically) if you omit the stop
-  // and start conditions. In order to do that, however, we'd have to revert to
-  // using raw ioctl() calls. So we'll cross that bridge if/when we get there
-
-  /*
-  x_l = wiringPiI2CReadReg8(fd,OUT_X_L_G);
-  x_h = wiringPiI2CRead(fd);
-  y_l = wiringPiI2CRead(fd);
-  y_h = wiringPiI2CRead(fd);
-  z_l = wiringPiI2CRead(fd);
-  z_h = wiringPiI2CRead(fd);
-  printf("%X,%X,%X,%X,%X,%X\n",x_l,x_h,y_l,y_h,z_l,z_h);
-  */
-
-  // Store the data in the data opject
- /* data->x = x_l | (x_h << 8);
-  data->y = y_l | (y_h << 8);
-  data->z = z_l | (z_h << 8);
-  */
-  
-  data->x = (int16_t)wiringPiI2CReadReg16(fd,OUT_X_L_G);
-  data->y = (int16_t)wiringPiI2CReadReg16(fd,OUT_Y_L_G);
-  data->z = (int16_t)wiringPiI2CReadReg16(fd,OUT_Z_L_G);
+  read_bytes(fd,OUT_X_L_G,data,6);
 }
 
+/*
 void get_accel(int fd, struct a_data* data)
 {
   // If the data pointer is null, return now
@@ -76,16 +49,17 @@ void get_accel(int fd, struct a_data* data)
   y_h = wiringPiI2CRead(fd);
   z_l = wiringPiI2CRead(fd);
   z_h = wiringPiI2CRead(fd);
-  printf("%X,%X,%X,%X,%X,%X\n",x_l,x_h,y_l,y_h,z_l,z_h);
 
   // Store the data in the data opject
   data->x = x_l | (x_h << 8);
   data->y = y_l | (y_h << 8);
   data->z = z_l | (z_h << 8);
-}
+}*/
 
 int get_status(int fd)
 {
-  return wiringPiI2CReadReg8(fd,STATUS_REG1);
+  int stat;
+  read_byte(fd,STATUS_REG1,&stat);
+  return stat;
 }
 


### PR DESCRIPTION
Remove wiringPi

Because of reasons. The main reason being, I want to be able to burst data from the sensor quickly. For example. I can write one register and read 12 times to get the gyro and accel data in one I2C transation. WiringPi uses smbus commands in the background, which means I could at best write one byte and read two. So to read the same 12 bytes of data, WiringPi needs 6 writes, while I only need 1.
